### PR TITLE
Fix build for 5.19.3

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1189,10 +1189,10 @@ check_bss:
 		#endif
 
 		#if defined(CPTCFG_VERSION) || LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
-	#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
-		roam_info.bssid = cur_network->network.MacAddress;
-	#else
+	#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0)
 		roam_info.links[0].bssid = cur_network->network.MacAddress;
+	#else
+		roam_info.bssid = cur_network->network.MacAddress;
 	#endif
 		roam_info.req_ie = pmlmepriv->assoc_req + sizeof(struct rtw_ieee80211_hdr_3addr) + 2;
 		roam_info.req_ie_len = pmlmepriv->assoc_req_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 2;
@@ -6338,7 +6338,7 @@ static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
 static int cfg80211_rtw_get_channel(struct wiphy *wiphy,
 	struct wireless_dev *wdev,
-#if (LINUX_VERSION_CODE >=  KERNEL_VERSION(6, 0, 0))
+#if (LINUX_VERSION_CODE >=  KERNEL_VERSION(5, 19, 2))
 	unsigned int link_id,
 #endif
 	struct cfg80211_chan_def *chandef)


### PR DESCRIPTION
你好，
最新dev 在我这里编译不过去了。错误是：
```
/tmp/rtl8852be/os_dep/linux/ioctl_cfg80211.c: In function ‘rtw_cfg80211_indicate_connect’:
/tmp/rtl8852be/os_dep/linux/ioctl_cfg80211.c:1195:26: error: ‘struct cfg80211_roam_info’ has no member named ‘links’
 1195 |                 roam_info.links[0].bssid = cur_network->network.MacAddress;
      |                          ^
/tmp/rtl8852be/os_dep/linux/ioctl_cfg80211.c: At top level:
/tmp/rtl8852be/os_dep/linux/ioctl_cfg80211.c:10447:24: error: initialization of ‘int (*)(struct wiphy *, struct wireless_dev *, unsigned int,  struct cfg80211_chan_def *)’ from incompatible pointer type ‘int (*)(struct wiphy *, struct wireless_dev *, struct cfg80211_chan_def *)’ [-Werror=incompatible-pointer-types]
10447 |         .get_channel = cfg80211_rtw_get_channel,
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~
```
我用的是Arch Linux，内核是5.19.3-zen1-1-zen.
我尝试直接使用lwfinger的rtw8852be, 编译可以通过，安装重启后依然无法找到WIFI.
参考了https://github.com/lwfinger/rtw8852be/blob/main/os_dep/linux/ioctl_cfg80211.c 修改了这里，编译完成后顺利启动WIFI.
