### PR TITLE
Instructions for driver support in Fedora 36

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,27 @@ Support CI/CD based on Github-hosted runners: Ubuntu 18.04, Ubuntu 20.04, Ubuntu
 ## Introduction
 This code is cloned from [TinkerBoard2/kernel](https://github.com/TinkerBoard2/kernel) and it's author is Rock_Shen (rock_shen@asus.com).  
 The default compilation option is i386_PC For Linux, you can also change the compilation options of MAKEFILE in line149.  
-## Prerequisites
+## Prerequisites (for Ubuntu/Debian)
 ```
 build-essential 
 linux-headers
 bc
 ```
+## Prerequisites (for Fedora)
+```
+kernel-headers
+kernel-devel-`uname -r`
+make
+automake
+cmake
+gcc
+gcc-c++
+bc
+```
+
+
+
+
 ## Build(for kernel < 5.18)
 ```
 #Turn off your Security Boot in BIOS


### PR DESCRIPTION
- Added required prerequisites to be installed for the driver to get built in Fedora 36.
- Tested on a Lenovo IdeaPad 5 Pro running Fedora Workstation 36.
